### PR TITLE
Better Parallax API

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ The api should look something like
 
 ```elixir
 Parallax.new()
-|> Parallax.parallel(:first, &first_func/1)
-|> Parallax.parallel(:second, &second_func/1)
-|> Parallax.nest(:nested, additional_sequence)
-|> Parallax.sync(:cleanup, fn %{first: f, second: s, nested: nested} -> cleanup(f, s, nested) end)
+|> Parallax.operation(:first, &first_func/1)
+|> Parallax.operation(:second, &second_func/1)
+|> Parallax.operation(:nested, additional_sequence)
+|> Parallax.operation(:cleanup, fn f, s, nested -> 
+  cleanup(f, s, nested) 
+end, requires: [:first, :second, :nested])
 |> Parallax.execute()
 ```
 

--- a/lib/parallax.ex
+++ b/lib/parallax.ex
@@ -1,23 +1,38 @@
 defmodule Parallax do
   @moduledoc """
-  Simple module for orchestrating parallel tasks.  There are three main options:
+  Simple module for orchestrating parallel tasks.
+
+  There are two basic abstractions for a Parallax operation, a `Parallax.Graph.t`,
+  created by `new/0`, or a `Parallax.Sequence.t`, created by `sequence/0`.  The latter
+  allows you to tweak your own parallelism structure, while the graph infers an optimal
+  parallelism strategy from the dependency DAG defined by subsequent calls to `operation/4`.
+
+  There are three main ways to add to sequences:
 
   * `sync/3` - appends a task to be executed synchronously
   * `parallel/3` - adds the task to be executed in parallel within the current batch
   * `nest/3` - nests an existing Parallax.Executable within the current batch
 
+  To add to a graph, simply do `Parallax.sync(graph, :name, fun, requires: :requirement)` (also
+  accepting a list of requirements)
+
   To execute the operation, simply call `Parallax.execute/1`
 
   All require a unique name so the result can be addressed after execution
   """
-  alias Parallax.{Sequence, Batch, Executor}
+  alias Parallax.{Sequence, Graph, Batch, Executor}
 
   @type executable :: Batch.t | Sequence.t | (map -> any)
 
   @doc """
   Creates a new sequence with the given opts to pass along
   """
-  def new(args \\ %{}, opts \\ []), do: %Sequence{args: args, opts: opts}
+  def new(args \\ %{}, opts \\ []), do: %Graph{args: args, opts: opts}
+
+  def sequence(args \\ %{}, opts \\ []), do: %Sequence{args: args, opts: opts}
+
+  def operation(%Graph{deps: deps, adj: adj} = graph, name, operation, requires \\ []),
+    do: Graph.add_node(graph, name, operation, Keyword.get(requires, :requires, :root))
 
   @doc  """
   Appends a new batch to the sequence, and adds the given operation to it.  Sequence ops are
@@ -43,4 +58,5 @@ defmodule Parallax do
     do: parallel(seq, name, operation)
 
   def execute(%Sequence{} = sequence), do: Executor.execute(sequence)
+  def execute(%Graph{} = graph), do: Executor.execute(graph)
 end

--- a/lib/parallax/executable.ex
+++ b/lib/parallax/executable.ex
@@ -18,6 +18,14 @@ defimpl Parallax.Executable, for: Function do
   end
 end
 
+defimpl Parallax.Executable, for: Tuple do
+  @doc """
+  Accepts a tuple like `{fun, requirements}` and calls the function
+  with the requirements mapped to the functions positional arguments
+  """
+  def execute({fun, requirements}, args), do: apply(fun, Enum.map(requirements, &Map.get(args, &1)))
+end
+
 defimpl Parallax.Executable, for: Parallax.Batch do
   @doc """
   Parallelizes the given set of ops by passing `args` to each and returns a map of names to results
@@ -58,5 +66,15 @@ defimpl Parallax.Executable, for: Parallax.Sequence do
       %Parallax.Result{results: results} -> maybe_halt(rest, Map.merge(args, results))
       map when is_map(map) -> maybe_halt(rest, Map.merge(args, map))
     end
+  end
+end
+
+defimpl Parallax.Executable, for: Parallax.Graph do
+  @doc """
+  Compiles the graph into a `Parallax.Sequence.t` and executes it
+  """
+  def execute(graph, args) do
+    Parallax.Graph.compile(graph)
+    |> Parallax.Executable.execute(args)
   end
 end

--- a/lib/parallax/graph.ex
+++ b/lib/parallax/graph.ex
@@ -1,0 +1,65 @@
+defmodule Parallax.Graph do
+  @moduledoc """
+  Repesents a graph of parallizable operations.  `Parallax.Executable` will topsort it from root, and
+  parallize where possible
+  """
+
+  @type t :: %__MODULE__{}
+  defstruct [
+    deps: %{},
+    operations: %{},
+    adj: %{},
+    opts: [],
+    args: %{}
+  ]
+
+  def add_node(seq, name, op, requirement) when is_atom(requirement), do: add_node(seq, name, op, [requirement])
+  def add_node(%__MODULE__{operations: operations, deps: deps, adj: adj} = seq, name, op, requirements) do
+    adj  = Enum.reduce(requirements, adj, &add_dep(&2, &1, name))
+    %{seq | adj: adj, operations: Map.put(operations, name, op), deps: Map.put(deps, name, requirements)}
+  end
+
+
+  @doc """
+  Sequence the parallel operation by:
+
+  1. Generating the max level in the dependency tree for each operation
+  2. Group the operations by that level
+  3. Executing each level in parallel, in sorted order
+  """
+  def compile(%__MODULE__{adj: adj, deps: deps, operations: ops, opts: opts, args: args}) do
+    levels  = build_levels(adj)
+    grouped = Enum.group_by(levels, &elem(&1, 1), &elem(&1, 0))
+
+    grouped
+    |> Map.keys()
+    |> Enum.sort()
+    |> Enum.reduce(Parallax.sequence(args, opts), fn level, parallax ->
+      [name | rest] = Map.get(grouped, level)
+
+      rest
+      |> Enum.reduce(Parallax.sync(parallax, name, operation(ops, name, deps)), fn name, parallax ->
+        Parallax.parallel(parallax, name, operation(ops, name, deps))
+      end)
+    end)
+  end
+
+  defp build_levels(map), do: build_levels(%{}, [:root], 0, map)
+  defp build_levels(result, [], _level, _map), do: result
+  defp build_levels(result, last, level, map) do
+    nodes = Enum.flat_map(last, &Map.get(map, &1, []))
+
+    nodes
+    |> Enum.map(& {&1, level + 1})
+    |> Enum.into(result)
+    |> build_levels(nodes, level + 1, map)
+  end
+
+  defp operation(ops, name, deps) do
+    {ops[name], Enum.reject(deps[name], & &1 == :root)}
+  end
+
+  defp add_dep(deps, requirement, operation) do
+    Map.update(deps, requirement, [operation], fn l -> [operation | l] end)
+  end
+end

--- a/lib/parallax/parallizer.ex
+++ b/lib/parallax/parallizer.ex
@@ -1,4 +1,7 @@
 defmodule Parallax.Parallelizer do
+  @moduledoc """
+  Handles executing a function against an enumerable with defined concurrency limits
+  """
 
   def parallelize(enumerable, fun, opts \\ []) do
     enumerable


### PR DESCRIPTION
Introduces the concept of a parallax graph, inferred from dependencies defined in the
operations added to a parallax.  Basically now we can do:

```elixir
Parallax.new()
|> Parallax.operation(:first, fn -> 1 end)
|> Parallax.operation(:second, fn -> 2 end)
|> Parallax.operation(:third, fn second -> second + 1 end, requires: :second)
|> Parallax.operation(:fourth, fn first, third -> first + third end, requires: [:first, :third])
...
|> Parallax.execute()
```